### PR TITLE
Ignore generated outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,10 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Generated book outputs
+*.docx
+*.pdf
+*.epub
+/exports/
+/output/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # ebook-gen
+
+Generated output files (like `.docx`, `.pdf`, and `.epub`) are created when running the generator and should not be committed to the repository. They will appear in `exports/` or `output/` directories which are ignored.


### PR DESCRIPTION
## Summary
- Ignore generated book outputs (`.docx`, `.pdf`, `.epub`) and exports/output directories
- Document that generated download files are not committed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d8fab1504832bbb35f189715ed866