### PR TITLE
feat: add ebook generation and docx export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # ebook-gen
 
-Generated output files (like `.docx`, `.pdf`, and `.epub`) are created when running the generator and should not be committed to the repository. They will appear in `exports/` or `output/` directories which are ignored.
+A minimal eBook generator built with Next.js. Users can fill out a form, generate eBook chapters with OpenAI (or mock text if no API key), preview the Markdown, and download the result as `.md` or `.docx`.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) and fill out the form. Click **Generate** to produce the Markdown eBook.
+
+## Environment Variables
+
+- `OPENAI_API_KEY` *(optional)* – if provided, content is generated with OpenAI. Without it, mock content is returned for demo purposes.
+
+## Downloads
+
+- **Download .md** – saves the generated Markdown file.
+- **Download .docx** – sends the Markdown to `/api/export/docx` and returns a Word document. Basic Thai fonts are supported.
+
+Generated output files (`.md`, `.docx`, etc.) are ignored via `.gitignore` and should not be committed.
+
+## Build
+
+```bash
+npm run build
+```

--- a/app/api/export/docx/route.ts
+++ b/app/api/export/docx/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { markdownToDocx } from "../../../../lib/exporter";
+
+export async function POST(req: Request) {
+  const { markdown } = await req.json();
+  const buf = await markdownToDocx(markdown || "");
+  const arrayBuffer: ArrayBuffer = buf.buffer as ArrayBuffer;
+  return new NextResponse(arrayBuffer, {
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "Content-Disposition": 'attachment; filename="ebook.docx"',
+    },
+  });
+}

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,5 +1,40 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
+import { generateChapter } from "../../../lib/prompt";
 
-export async function POST() {
-  return NextResponse.json({ success: true });
+export async function POST(req: Request) {
+  const {
+    topic,
+    language,
+    audience,
+    tone,
+    chapters,
+    wordsPerChapter,
+    includeExamples,
+  } = await req.json();
+
+  const isThai = language === "th";
+  const title = isThai ? `หนังสือเกี่ยวกับ ${topic}` : `Ebook about ${topic}`;
+  const tocHeader = isThai ? "สารบัญ" : "Table of Contents";
+  const chapterLabel = isThai ? "บทที่" : "Chapter";
+
+  const toc: string[] = [];
+  const content: string[] = [];
+
+  for (let i = 1; i <= chapters; i++) {
+    toc.push(`- ${chapterLabel} ${i}`);
+    const chapter = await generateChapter({
+      topic,
+      language,
+      audience,
+      tone,
+      i,
+      wordsPerChapter,
+      includeExamples,
+    });
+    content.push(`# ${chapterLabel} ${i}\n\n${chapter}`);
+  }
+
+  const markdown = `# ${title}\n\n## ${tocHeader}\n${toc.join("\n")}\n\n${content.join("\n\n")}`;
+
+  return NextResponse.json({ markdown });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,183 @@
+"use client";
+
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+
 export default function Home() {
+  const [form, setForm] = useState({
+    topic: "",
+    language: "en",
+    audience: "",
+    tone: "friendly",
+    chapters: 5,
+    wordsPerChapter: 400,
+    includeExamples: false,
+  });
+  const [markdown, setMarkdown] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const target = e.target as HTMLInputElement | HTMLSelectElement;
+    const { name, value, type } = target;
+    setForm((prev) => ({
+      ...prev,
+      [name]:
+        type === "checkbox"
+          ? (target as HTMLInputElement).checked
+          : type === "number"
+          ? Number(value)
+          : value,
+    }));
+  };
+
+  const handleGenerate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setMarkdown("");
+    const res = await fetch("/api/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(form),
+    });
+    const data = await res.json();
+    setMarkdown(data.markdown || "");
+    setLoading(false);
+  };
+
+  const downloadMd = () => {
+    const blob = new Blob([markdown], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "ebook.md";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const downloadDocx = async () => {
+    const res = await fetch("/api/export/docx", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ markdown }),
+    });
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "ebook.docx";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold">Welcome to ebook generator</h1>
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">eBook Generator</h1>
+      <form onSubmit={handleGenerate} className="space-y-2 max-w-md">
+        <input
+          className="w-full border p-2"
+          placeholder="Topic"
+          name="topic"
+          value={form.topic}
+          onChange={handleChange}
+          required
+        />
+        <input
+          className="w-full border p-2"
+          placeholder="Audience"
+          name="audience"
+          value={form.audience}
+          onChange={handleChange}
+          required
+        />
+        <div className="flex gap-2">
+          <label className="flex flex-col text-sm">
+            Language
+            <select
+              name="language"
+              value={form.language}
+              onChange={handleChange}
+              className="border p-2"
+            >
+              <option value="en">English</option>
+              <option value="th">ไทย</option>
+            </select>
+          </label>
+          <label className="flex flex-col text-sm">
+            Tone
+            <select
+              name="tone"
+              value={form.tone}
+              onChange={handleChange}
+              className="border p-2"
+            >
+              <option value="friendly">Friendly</option>
+              <option value="professional">Professional</option>
+            </select>
+          </label>
+        </div>
+        <div className="flex gap-2">
+          <label className="flex flex-col text-sm">
+            Chapters
+            <input
+              type="number"
+              name="chapters"
+              min={5}
+              max={12}
+              value={form.chapters}
+              onChange={handleChange}
+              className="border p-2"
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            Words/Chapter
+            <input
+              type="number"
+              name="wordsPerChapter"
+              min={400}
+              max={800}
+              value={form.wordsPerChapter}
+              onChange={handleChange}
+              className="border p-2"
+            />
+          </label>
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            name="includeExamples"
+            checked={form.includeExamples}
+            onChange={handleChange}
+          />
+          Include examples
+        </label>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+          disabled={loading}
+        >
+          Generate
+        </button>
+      </form>
+
+      {loading && <p>Generating...</p>}
+
+      {markdown && !loading && (
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <button onClick={downloadMd} className="px-3 py-1 bg-gray-200 rounded">
+              Download .md
+            </button>
+            <button onClick={downloadDocx} className="px-3 py-1 bg-gray-200 rounded">
+              Download .docx
+            </button>
+          </div>
+          <div className="prose max-w-none">
+            <ReactMarkdown>{markdown}</ReactMarkdown>
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/lib/exporter.ts
+++ b/lib/exporter.ts
@@ -1,0 +1,50 @@
+import { Document, HeadingLevel, Packer, Paragraph } from "docx";
+
+export async function markdownToDocx(markdown: string): Promise<Uint8Array> {
+  const lines = markdown.split(/\r?\n/);
+  const children: Paragraph[] = [];
+
+  for (const line of lines) {
+    if (line.startsWith("# ")) {
+      children.push(
+        new Paragraph({
+          text: line.replace(/^#\s+/, "").trim(),
+          heading: HeadingLevel.HEADING_1,
+        })
+      );
+    } else if (line.startsWith("## ")) {
+      children.push(
+        new Paragraph({
+          text: line.replace(/^##\s+/, "").trim(),
+          heading: HeadingLevel.HEADING_2,
+        })
+      );
+    } else if (line.startsWith("- ")) {
+      children.push(
+        new Paragraph({
+          text: line.replace(/^-\s+/, "").trim(),
+          bullet: { level: 0 },
+        })
+      );
+    } else if (line.trim() === "") {
+      children.push(new Paragraph(""));
+    } else {
+      children.push(new Paragraph(line));
+    }
+  }
+
+  const doc = new Document({
+    styles: {
+      default: {
+        document: {
+          run: {
+            font: "TH Sarabun New",
+          },
+        },
+      },
+    },
+    sections: [{ properties: {}, children }],
+  });
+
+  return Packer.toBuffer(doc);
+}

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -1,0 +1,66 @@
+import OpenAI from "openai";
+
+export interface GenerateChapterParams {
+  topic: string;
+  language: "th" | "en";
+  audience: string;
+  tone: "friendly" | "professional";
+  i: number;
+  wordsPerChapter: number;
+  includeExamples: boolean;
+}
+
+export async function generateChapter({
+  topic,
+  language,
+  audience,
+  tone,
+  i,
+  wordsPerChapter,
+  includeExamples,
+}: GenerateChapterParams): Promise<string> {
+  const langLabel = language === "th" ? "Thai" : "English";
+  const toneLabel = tone === "friendly" ? (language === "th" ? "เป็นกันเอง" : "friendly") : (language === "th" ? "เป็นทางการ" : "professional");
+  const exampleLabel = includeExamples
+    ? language === "th"
+      ? "และยกตัวอย่างที่เกี่ยวข้อง"
+      : "and include relevant examples"
+    : language === "th"
+    ? "และไม่ต้องยกตัวอย่าง"
+    : "and no examples";
+
+  const prompt = `Write chapter ${i} of an eBook about "${topic}" in ${langLabel}.
+Target audience: ${audience}.
+Tone: ${toneLabel}.
+Around ${wordsPerChapter} words ${exampleLabel}.
+Structure:
+- Introduction
+- Bullet points
+${includeExamples ? "- Examples\n" : ""}- Summary (3-5 sentences)`;
+
+  if (process.env.OPENAI_API_KEY) {
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const res = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: prompt }],
+    });
+    return res.choices[0].message?.content?.trim() ?? "";
+  }
+
+  const intro = language === "th"
+    ? `ในบทที่ ${i} เราจะพูดถึง ${topic} สำหรับผู้อ่านกลุ่ม ${audience}.`
+    : `In chapter ${i}, we discuss ${topic} for ${audience}.`;
+  const bullets = language === "th"
+    ? "- ประเด็นสำคัญ 1\n- ประเด็นสำคัญ 2\n- ประเด็นสำคัญ 3"
+    : "- Key point 1\n- Key point 2\n- Key point 3";
+  const example = includeExamples
+    ? language === "th"
+      ? "\n\n**ตัวอย่าง:** ตัวอย่างประกอบเนื้อหา."
+      : "\n\n**Example:** An example related to the topic."
+    : "";
+  const summary = language === "th"
+    ? "\n\nสรุป:\n- สรุปสั้น ๆ 1\n- สรุปสั้น ๆ 2\n- สรุปสั้น ๆ 3"
+    : "\n\nSummary:\n- Short summary 1\n- Short summary 2\n- Short summary 3";
+
+  return `${intro}\n\n${bullets}${example}${summary}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "docx": "latest",
         "next": "latest",
+        "openai": "^5.12.2",
         "react": "latest",
         "react-dom": "latest",
         "react-markdown": "latest"
@@ -2626,6 +2627,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
+      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/pako": {

--- a/package.json
+++ b/package.json
@@ -8,18 +8,19 @@
     "start": "next start"
   },
   "dependencies": {
+    "docx": "latest",
     "next": "latest",
+    "openai": "^5.12.2",
     "react": "latest",
     "react-dom": "latest",
-    "react-markdown": "latest",
-    "docx": "latest"
+    "react-markdown": "latest"
   },
   "devDependencies": {
-    "typescript": "latest",
-    "tailwindcss": "latest",
-    "postcss": "latest",
+    "@tailwindcss/postcss": "latest",
     "autoprefixer": "latest",
-    "@tailwindcss/postcss": "latest"
+    "postcss": "latest",
+    "tailwindcss": "latest",
+    "typescript": "latest"
   },
   "engines": {
     "node": ">=18.17"


### PR DESCRIPTION
## Summary
- build a form-driven eBook generator UI with markdown preview and download buttons
- implement chapter generation with OpenAI or mock text
- add DOCX exporter and API routes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f0c0300d4832bb1d5a6282d0326da