### PR TITLE
feat: improve ebook generation prompts and flow

### DIFF
--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -1,7 +1,16 @@
 import OpenAI from "openai";
 
+export interface GenerateTitleAndTocParams {
+  topic: string;
+  language: "th" | "en";
+  audience: string;
+  tone: "friendly" | "professional";
+  chapters: number;
+}
+
 export interface GenerateChapterParams {
   topic: string;
+  chapterTitle: string;
   language: "th" | "en";
   audience: string;
   tone: "friendly" | "professional";
@@ -10,8 +19,77 @@ export interface GenerateChapterParams {
   includeExamples: boolean;
 }
 
+function getToneLabel(language: "th" | "en", tone: "friendly" | "professional") {
+  if (tone === "friendly") {
+    return language === "th" ? "เป็นกันเอง" : "friendly";
+  }
+  return language === "th" ? "เป็นทางการ" : "professional";
+}
+
+export async function generateTitleAndToc({
+  topic,
+  language,
+  audience,
+  tone,
+  chapters,
+}: GenerateTitleAndTocParams): Promise<{ title: string; toc: string[] }> {
+  const langLabel = language === "th" ? "Thai" : "English";
+  const toneLabel = getToneLabel(language, tone);
+  const prompt = `Create an ebook title and table of contents in ${langLabel}.
+Topic: "${topic}".
+Audience: ${audience}.
+Tone: ${toneLabel}.
+Provide ${chapters} specific chapter titles covering distinct aspects of the topic.
+Return JSON: {"title": string, "toc": string[]}.`;
+
+  if (process.env.OPENAI_API_KEY) {
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const res = await client.chat.completions.create({
+      model: "gpt-4o-mini",
+      temperature: 0.4,
+      messages: [{ role: "user", content: prompt }],
+    });
+    const text = res.choices[0].message?.content?.trim() ?? "";
+    try {
+      const json = JSON.parse(text);
+      const toc: string[] = Array.isArray(json.toc)
+        ? json.toc.slice(0, chapters).map((t: string) => t.trim())
+        : [];
+      return { title: String(json.title ?? topic), toc };
+    } catch {
+      const lines = text.split("\n");
+      const title = lines[0] || topic;
+      const toc = lines.slice(1, chapters + 1).map((l) => l.replace(/^[-*]\s*/, "").trim());
+      return { title, toc };
+    }
+  }
+
+  const isThai = language === "th";
+  const title = isThai ? `คู่มือ${topic}` : `${topic} Handbook`;
+  const templatesTh = [
+    `พื้นฐานของ ${topic}`,
+    `การนำ ${topic} ไปใช้จริง`,
+    `กรณีศึกษาเกี่ยวกับ ${topic}`,
+    `ปัญหาและทางออกของ ${topic}`,
+    `แนวโน้มอนาคตของ ${topic}`,
+  ];
+  const templatesEn = [
+    `Fundamentals of ${topic}`,
+    `Practical Uses of ${topic}`,
+    `Case Study of ${topic}`,
+    `Challenges and Solutions in ${topic}`,
+    `Future Trends of ${topic}`,
+  ];
+  const base = isThai ? templatesTh : templatesEn;
+  const toc = Array.from({ length: chapters }, (_, idx) =>
+    base[idx] || (isThai ? `${topic} แง่มุมที่ ${idx + 1}` : `${topic} Aspect ${idx + 1}`)
+  );
+  return { title, toc };
+}
+
 export async function generateChapter({
   topic,
+  chapterTitle,
   language,
   audience,
   tone,
@@ -20,47 +98,45 @@ export async function generateChapter({
   includeExamples,
 }: GenerateChapterParams): Promise<string> {
   const langLabel = language === "th" ? "Thai" : "English";
-  const toneLabel = tone === "friendly" ? (language === "th" ? "เป็นกันเอง" : "friendly") : (language === "th" ? "เป็นทางการ" : "professional");
-  const exampleLabel = includeExamples
-    ? language === "th"
-      ? "และยกตัวอย่างที่เกี่ยวข้อง"
-      : "and include relevant examples"
-    : language === "th"
-    ? "และไม่ต้องยกตัวอย่าง"
-    : "and no examples";
-
-  const prompt = `Write chapter ${i} of an eBook about "${topic}" in ${langLabel}.
-Target audience: ${audience}.
+  const toneLabel = getToneLabel(language, tone);
+  const prompt = `Write chapter ${i} titled "${chapterTitle}" for an ebook about "${topic}" in ${langLabel}.
+Audience: ${audience}.
 Tone: ${toneLabel}.
-Around ${wordsPerChapter} words ${exampleLabel}.
+Length: about ${wordsPerChapter} words (±15%).
+Avoid generic phrases like "in this chapter we will".
 Structure:
-- Introduction
-- Bullet points
-${includeExamples ? "- Examples\n" : ""}- Summary (3-5 sentences)`;
+- Intro: 2-3 lines.
+- 3-5 bullet points with detailed steps, numbers, or insights.
+${includeExamples ? "- Include a real-world example or case study.\n" : ""}- Summary: 3-5 lines followed by a checklist of key points.`;
 
   if (process.env.OPENAI_API_KEY) {
     const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     const res = await client.chat.completions.create({
       model: "gpt-4o-mini",
+      temperature: 0.4,
       messages: [{ role: "user", content: prompt }],
     });
     return res.choices[0].message?.content?.trim() ?? "";
   }
 
-  const intro = language === "th"
-    ? `ในบทที่ ${i} เราจะพูดถึง ${topic} สำหรับผู้อ่านกลุ่ม ${audience}.`
-    : `In chapter ${i}, we discuss ${topic} for ${audience}.`;
-  const bullets = language === "th"
-    ? "- ประเด็นสำคัญ 1\n- ประเด็นสำคัญ 2\n- ประเด็นสำคัญ 3"
-    : "- Key point 1\n- Key point 2\n- Key point 3";
+  const isThai = language === "th";
+  const intro = isThai
+    ? `${chapterTitle} มีบทบาทสำคัญต่อกลุ่ม ${audience}\nการเข้าใจหัวข้อนี้ช่วยพัฒนาการทำงานได้ดีขึ้น`
+    : `${chapterTitle} is crucial for ${audience}\nUnderstanding this topic improves practical work`;
+  const bullets = isThai
+    ? `- ขั้นตอนหลักของ ${chapterTitle}\n- เทคนิคที่ควรรู้\n- ตัวเลขที่ต้องติดตาม`
+    : `- Key steps of ${chapterTitle}\n- Useful techniques\n- Metrics to monitor`;
   const example = includeExamples
-    ? language === "th"
-      ? "\n\n**ตัวอย่าง:** ตัวอย่างประกอบเนื้อหา."
-      : "\n\n**Example:** An example related to the topic."
+    ? isThai
+      ? `\n\n**กรณีศึกษา:** การใช้ ${chapterTitle} ในบริษัทตัวอย่าง`
+      : `\n\n**Case Study:** Using ${chapterTitle} in a sample company`
     : "";
-  const summary = language === "th"
-    ? "\n\nสรุป:\n- สรุปสั้น ๆ 1\n- สรุปสั้น ๆ 2\n- สรุปสั้น ๆ 3"
-    : "\n\nSummary:\n- Short summary 1\n- Short summary 2\n- Short summary 3";
-
-  return `${intro}\n\n${bullets}${example}${summary}`;
+  const summaryText = isThai
+    ? `สรุปใจความของ ${chapterTitle}\nลองปฏิบัติตามเพื่อเห็นผลจริง\nประเมินและปรับปรุงสม่ำเสมอ`
+    : `Key points of ${chapterTitle}\nApply the steps to see results\nReview and refine regularly`;
+  const checklistItems = isThai
+    ? ["ทำความเข้าใจ", "ลงมือทำ", "วัดผล"]
+    : ["Understand", "Act", "Measure"];
+  const checklist = checklistItems.map((c) => `- [ ] ${c}`).join("\n");
+  return `${intro}\n\n${bullets}${example}\n\n${isThai ? "สรุป:" : "Summary:"}\n${summaryText}\n\n${isThai ? "Checklist:" : "Checklist:"}\n${checklist}`;
 }


### PR DESCRIPTION
## Summary
- add two-stage generation for ebook title and specific chapter TOC
- expand chapter prompt with intro, detailed bullets, optional examples, and summary checklist
- update API route to orchestrate new flow and use temperature 0.4

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f4f7fe334832bb63fb20c3248a1cb