### PR TITLE
feat: polish markdown preview and form layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,19 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+
+@layer base {
+  body {
+    @apply bg-white text-gray-800 antialiased;
+  }
+}
+
+@layer components {
+  .btn {
+    @apply px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50;
+  }
+  .btn-secondary {
+    @apply px-3 py-1 rounded bg-gray-200 hover:bg-gray-300;
+  }
+  .input {
+    @apply w-full border rounded p-2;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,112 +72,141 @@ export default function Home() {
   };
 
   return (
-    <main className="p-4 space-y-4">
+    <main className="container mx-auto p-4 space-y-8">
       <h1 className="text-2xl font-bold">eBook Generator</h1>
-      <form onSubmit={handleGenerate} className="space-y-2 max-w-md">
-        <input
-          className="w-full border p-2"
-          placeholder="Topic"
-          name="topic"
-          value={form.topic}
-          onChange={handleChange}
-          required
-        />
-        <input
-          className="w-full border p-2"
-          placeholder="Audience"
-          name="audience"
-          value={form.audience}
-          onChange={handleChange}
-          required
-        />
-        <div className="flex gap-2">
-          <label className="flex flex-col text-sm">
-            Language
-            <select
-              name="language"
-              value={form.language}
-              onChange={handleChange}
-              className="border p-2"
-            >
-              <option value="en">English</option>
-              <option value="th">ไทย</option>
-            </select>
-          </label>
-          <label className="flex flex-col text-sm">
-            Tone
-            <select
-              name="tone"
-              value={form.tone}
-              onChange={handleChange}
-              className="border p-2"
-            >
-              <option value="friendly">Friendly</option>
-              <option value="professional">Professional</option>
-            </select>
-          </label>
-        </div>
-        <div className="flex gap-2">
-          <label className="flex flex-col text-sm">
-            Chapters
+      <div className="grid gap-8 lg:grid-cols-2">
+        <form onSubmit={handleGenerate} className="space-y-4">
+          <div>
+            <label htmlFor="topic" className="block text-sm font-medium mb-1">
+              Topic
+            </label>
             <input
-              type="number"
-              name="chapters"
-              min={5}
-              max={12}
-              value={form.chapters}
+              id="topic"
+              className="input"
+              placeholder="Topic"
+              name="topic"
+              value={form.topic}
               onChange={handleChange}
-              className="border p-2"
+              required
             />
-          </label>
-          <label className="flex flex-col text-sm">
-            Words/Chapter
+          </div>
+          <div>
+            <label htmlFor="audience" className="block text-sm font-medium mb-1">
+              Audience
+            </label>
             <input
-              type="number"
-              name="wordsPerChapter"
-              min={400}
-              max={800}
-              value={form.wordsPerChapter}
+              id="audience"
+              className="input"
+              placeholder="Audience"
+              name="audience"
+              value={form.audience}
               onChange={handleChange}
-              className="border p-2"
+              required
             />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="language" className="block text-sm font-medium mb-1">
+                Language
+              </label>
+              <select
+                id="language"
+                name="language"
+                value={form.language}
+                onChange={handleChange}
+                className="input"
+              >
+                <option value="en">English</option>
+                <option value="th">ไทย</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="tone" className="block text-sm font-medium mb-1">
+                Tone
+              </label>
+              <select
+                id="tone"
+                name="tone"
+                value={form.tone}
+                onChange={handleChange}
+                className="input"
+              >
+                <option value="friendly">Friendly</option>
+                <option value="professional">Professional</option>
+              </select>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label
+                htmlFor="chapters"
+                className="block text-sm font-medium mb-1"
+              >
+                Chapters
+              </label>
+              <input
+                type="number"
+                id="chapters"
+                name="chapters"
+                min={5}
+                max={12}
+                value={form.chapters}
+                onChange={handleChange}
+                className="input"
+              />
+            </div>
+            <div>
+              <label
+                htmlFor="wordsPerChapter"
+                className="block text-sm font-medium mb-1"
+              >
+                Words/Chapter
+              </label>
+              <input
+                type="number"
+                id="wordsPerChapter"
+                name="wordsPerChapter"
+                min={400}
+                max={800}
+                value={form.wordsPerChapter}
+                onChange={handleChange}
+                className="input"
+              />
+            </div>
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              name="includeExamples"
+              checked={form.includeExamples}
+              onChange={handleChange}
+            />
+            Include examples
           </label>
-        </div>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            name="includeExamples"
-            checked={form.includeExamples}
-            onChange={handleChange}
-          />
-          Include examples
-        </label>
-        <button
-          type="submit"
-          className="px-4 py-2 bg-blue-600 text-white rounded"
-          disabled={loading}
-        >
-          Generate
-        </button>
-      </form>
+          <button type="submit" className="btn" disabled={loading}>
+            Generate
+          </button>
+        </form>
+        <div>
+          {loading && <p>Generating...</p>}
 
-      {loading && <p>Generating...</p>}
-
-      {markdown && !loading && (
-        <div className="space-y-4">
-          <div className="flex gap-2">
-            <button onClick={downloadMd} className="px-3 py-1 bg-gray-200 rounded">
-              Download .md
-            </button>
-            <button onClick={downloadDocx} className="px-3 py-1 bg-gray-200 rounded">
-              Download .docx
-            </button>
-          </div>
-          <div className="prose max-w-none">
-            <ReactMarkdown>{markdown}</ReactMarkdown>
-          </div>
+          {markdown && !loading && (
+            <div className="space-y-4">
+              <div className="flex flex-wrap gap-2">
+                <button onClick={downloadMd} className="btn-secondary">
+                  Download .md
+                </button>
+                <button onClick={downloadDocx} className="btn-secondary">
+                  Download .docx
+                </button>
+              </div>
+              <article className="prose max-w-none lg:prose-lg">
+                <ReactMarkdown>{markdown}</ReactMarkdown>
+              </article>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </main>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "latest",
+        "@tailwindcss/typography": "^0.5.16",
         "autoprefixer": "latest",
         "postcss": "latest",
         "tailwindcss": "latest",
@@ -952,6 +953,22 @@
         "tailwindcss": "4.1.11"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
+      "integrity": "sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -1258,6 +1275,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -1829,6 +1859,27 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -2714,6 +2765,20 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-value-parser": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "latest",
+    "@tailwindcss/typography": "^0.5.16",
     "autoprefixer": "latest",
     "postcss": "latest",
     "tailwindcss": "latest",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,11 @@
 import type { Config } from 'tailwindcss';
+import typography from '@tailwindcss/typography';
 
 const config: Config = {
   content: ['./app/**/*.{ts,tsx}'],
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [typography],
 };
 export default config;


### PR DESCRIPTION
## Summary
- add Tailwind typography plugin and global button/input styles
- revamp form layout with responsive grid and button utilities
- render Markdown preview inside styled article with prose classes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f51810888832bb2f08dd5f9cc4057