### PR TITLE
feat: prompt v2 with two-pass generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A minimal eBook generator built with Next.js. Users can fill out a form, generate eBook chapters with OpenAI (or mock text if no API key), preview the Markdown, and download the result as `.md` or `.docx`.
 
+### Prompt V2
+
+Generation now uses a two-pass flow: first a specific title and table of contents are created, then each chapter is written following that outline with actionable subsections, optional real examples, and a summary checklist.
+
 ## Getting Started
 
 ```bash

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     chapters,
   });
 
-  const content: string[] = [];
+  const chaptersContent: string[] = [];
 
   for (let i = 0; i < chapters; i++) {
     const chapterTitle = toc[i] || `${chapterLabel} ${i + 1}`;
@@ -38,11 +38,11 @@ export async function POST(req: Request) {
       wordsPerChapter,
       includeExamples,
     });
-    content.push(`# ${chapterLabel} ${i + 1}: ${chapterTitle}\n\n${chapter}`);
+    chaptersContent.push(`# ${chapterLabel} ${i + 1}: ${chapterTitle}\n\n${chapter}`);
   }
 
   const tocList = toc.map((t, idx) => `- ${chapterLabel} ${idx + 1}: ${t}`);
-  const markdown = `# ${title}\n\n## ${tocHeader}\n${tocList.join("\n")}\n\n${content.join("\n\n")}`;
+  const markdown = `# ${title}\n\n## ${tocHeader}\n${tocList.join("\n")}\n\n${chaptersContent.join("\n\n")}`;
 
-  return NextResponse.json({ markdown });
+  return NextResponse.json({ title, toc, markdown });
 }


### PR DESCRIPTION
## Summary
- refine title and TOC prompt to require specific, non-generic chapter names
- add prompt V2 for chapters with intros, actionable subsections, optional real examples, and summary checklists
- update API to run two-pass generation and return title and toc alongside markdown

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5e1f9b30832b8a1e4050569a1e72