### PR TITLE
feat: implement prompt v2.2 behavior-change flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A minimal eBook generator built with Next.js. Users can fill out a form, generate eBook chapters with OpenAI (or mock text if no API key), preview the Markdown, and download the result as `.md` or `.docx`.
 
-### Prompt V2.1
+### Prompt V2.2
 
-Generation uses a two-pass flow: first a specific title and table of contents are produced, then each chapter is written from that outline with concise intros, numbered steps, realistic examples, and a practical checklist. Common filler phrases are banned for clearer output.
+Generation still uses a two-pass flow, now with a behavior-change recipe. The first pass produces a specific title and table of contents (e.g., a 14‑day screen-time reset: Day 0 Baseline → Day 11–14 review). The second pass writes each chapter with a tight intro, numbered actions with concrete timers or frequencies, an optional realistic scenario, a daily/weekly tracker snippet, and a checklist. Banned filler phrases are enforced to keep output direct.
 
 ## Getting Started
 

--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -28,22 +28,21 @@ export async function POST(req: Request) {
     toc[idx] || `${chapterLabel} ${idx + 1}`
   );
 
-  const chaptersContent = await Promise.all(
-    tocArray.map((chapterTitle, idx) =>
-      generateChapter({
-        topic,
-        chapterTitle,
-        language,
-        audience,
-        tone,
-        i: idx + 1,
-        wordsPerChapter,
-        includeExamples,
-      }).then(
-        (chapter) => `# ${chapterLabel} ${idx + 1}: ${chapterTitle}\n\n${chapter}`
-      )
-    )
-  );
+  const chaptersContent: string[] = [];
+  for (let idx = 0; idx < tocArray.length; idx++) {
+    const chapterTitle = tocArray[idx];
+    const chapter = await generateChapter({
+      topic,
+      chapterTitle,
+      language,
+      audience,
+      tone,
+      i: idx + 1,
+      wordsPerChapter,
+      includeExamples,
+    });
+    chaptersContent.push(`# ${chapterLabel} ${idx + 1}: ${chapterTitle}\n\n${chapter}`);
+  }
 
   const tocList = tocArray.map((t, idx) => `- ${chapterLabel} ${idx + 1}: ${t}`);
   const markdown = `# ${title}\n\n## ${tocHeader}\n${tocList.join("\n")}\n\n${chaptersContent.join("\n\n")}`;


### PR DESCRIPTION
## Summary
- add Prompt V2.2 with strict filler bans and digital-wellbeing 14-day structure
- generate chapters with numbered actions, scenario, tracker snippet, and checklist
- sequentially build chapters from TOC and document behavior-change recipe in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02e72b84c832ba777a169fc42672d