### PR TITLE
feat: enforce howto prompt two-pass generation

### DIFF
--- a/app/api/generate/route.ts
+++ b/app/api/generate/route.ts
@@ -1,17 +1,31 @@
 import { NextResponse } from "next/server";
-import { generateChapter, generateTitleAndToc } from "../../../lib/prompt";
+import {
+  Style,
+  generateChapter,
+  generateTitleAndToc,
+} from "../../../lib/prompt";
 
 export async function POST(req: Request) {
+  const body = await req.json();
   const {
     topic,
     language,
     audience,
     tone,
-    style,
+    style = "howto",
     chapters,
     wordsPerChapter,
     includeExamples,
-  } = await req.json();
+  } = body as {
+    topic: string;
+    language: "th" | "en";
+    audience: string;
+    tone: "friendly" | "professional";
+    style?: Style;
+    chapters: number;
+    wordsPerChapter: number;
+    includeExamples: boolean;
+  };
 
   const isThai = language === "th";
   const tocHeader = isThai ? "สารบัญ" : "Table of Contents";


### PR DESCRIPTION
## Summary
- add ban list and two-pass regeneration to title/TOC and chapter creation
- require action-based, numbered titles and step-by-step howto subsections
- default API route to style="howto" and call generation in two-pass flow

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a08b2b8518832b8260a2ae923a88df